### PR TITLE
correct location of fonts

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -1,10 +1,10 @@
 @font-face {
     font-family: 'reg-popins';
-    src: url(/fonts/Poppins-Regular.ttf);
+    src: url(../fonts/Poppins-Regular.ttf);
 }
 @font-face {
     font-family: 'extrabold popins';
-    src: url(/fonts/Poppins-ExtraBold.ttf);
+    src: url(../fonts/Poppins-ExtraBold.ttf);
 }
 *{
     box-sizing: border-box;


### PR DESCRIPTION
Since the `fonts/` directory is not inside the `css/` directory, you have to change to its parent directory first before you go to fonts. To do that, you need to add two dots [`..`] to tell the browser that this relative location of the font is located to the stylesheet's parent directory and to another folder. Hence:

`../fonts/Poppins-Regular.ttf`
`../fonts/Poppins-ExtraBold.ttf`

When you write `fonts/Poppins-Regular.ttf`, you are telling the browser to look for a `fonts/` directory inside the `css/` directory, which does not exist.